### PR TITLE
✅ Tests: Added integration tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,9 +2,6 @@ from flask import Flask, render_template, request
 from dotenv import load_dotenv
 from peewee import *
 
-import os
-import datetime
-
 from app.utils.mysql_init import connect, create_tables
 from app.utils.api_experience import get_experience_func
 from app.utils.api_hobbies import get_hobbies_func
@@ -14,27 +11,9 @@ from app.utils.api_timeline import post_time_line_post_func, get_time_line_posts
 load_dotenv()
 app = Flask(__name__)
 
-mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
-    user=os.getenv("MYSQL_USER"),
-    password=os.getenv("MYSQL_PASSWORD"),
-    host=os.getenv("MYSQL_HOST"),
-    port=3306
-)
-
-class TimelinePost(Model):
-    name = CharField()
-    email = CharField()
-    content = TextField()
-    created_at = DateTimeField(default=datetime.datetime.now)
-
-    class Meta:
-        database = mydb
-
-mydb.connect()
-
 # MYSQL Connection
-# connect()
-# create_tables()
+connect()
+create_tables()
 
 @app.route('/')
 def index():

--- a/app/utils/api_timeline.py
+++ b/app/utils/api_timeline.py
@@ -1,12 +1,25 @@
 from playhouse.shortcuts import model_to_dict
 from app.utils.mysql_init import TimeLinePost
+import re
 
 def post_time_line_post_func(request):
+    # Name Validation (empty or not defined)
     name = request.form['name']
-    content = request.form['content']
-    email = request.form['email']
-    timeline_post = TimeLinePost.create(name = name, content = content, email = email)
+    if (name == "") or (name is None):
+        return "Invalid name", 400
 
+    # Content Validation (empty or not defined)
+    content = request.form['content']
+    if (content == "") or (content is None):
+        return "Invalid content", 400
+
+    # Email Validation (emtpy, not defined or invalid)
+    email = request.form['email']
+    email_regex = re.compile(r'([A-Za-z0-9]+[.-_])*[A-Za-z0-9]+@[A-Za-z0-9-]+(\.[A-Z|a-z]{2,})+')
+    if (email == "") or (email is None) or (not re.fullmatch(email_regex, email)):
+        return "Invalid email", 400
+
+    timeline_post = TimeLinePost.create(name = name, content = content, email = email)
     return model_to_dict(timeline_post)
 
 def get_time_line_posts_func():

--- a/app/utils/mysql_init.py
+++ b/app/utils/mysql_init.py
@@ -1,17 +1,49 @@
 import os 
 import datetime
 from peewee import *
+from dotenv import load_dotenv
 
-# MYSQL Connection
-mydb = MySQLDatabase(
-        os.getenv("MYSQL_DATABASE"),
-        user = os.getenv("MYSQL_USER"),
-        password = os.getenv("MYSQL_PASSWORD"),
-        host = os.getenv("MYSQL_HOST"),
-        port = 3306
-    )
+# Load environment variables --> Done for testing purposes
+load_dotenv()
 
-# Models
+# Initialize database as None
+mydb = None
+
+# Function to get database connection depending on the environment (Testing or not)
+def get_database():
+    global mydb
+
+    if mydb is None:
+        if os.getenv("TESTING") == "true":
+            print("Running in test mode")
+            mydb = SqliteDatabase('file:memory?mode=memory&cache=shared', uri=True)
+        else:
+            mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
+                user=os.getenv("MYSQL_USER"),
+                password=os.getenv("MYSQL_PASSWORD"),
+                host=os.getenv("MYSQL_HOST"),
+                port=3306
+            )
+    
+    return mydb
+
+# Function to initialize database to prevent when testing
+def db_int():
+    # Get database connection
+    db = get_database()
+    
+    if os.getenv("TESTING") == "true":
+            db.init('file:memory?mode=memory&cache=shared')
+    else:
+        db.init(os.getenv("MYSQL_DATABASE"),
+            user=os.getenv("MYSQL_USER"),
+            password=os.getenv("MYSQL_PASSWORD"),
+            host=os.getenv("MYSQL_HOST"),
+            port=3306
+        )
+    
+
+# Models used to create tables
 class TimeLinePost(Model):
     name = CharField()
     email = CharField()
@@ -19,7 +51,7 @@ class TimeLinePost(Model):
     created_at = DateTimeField(default = datetime.datetime.now)
 
     class Meta:
-        database = mydb
+        database = get_database()
 
 class Projects(Model):
     title = CharField()
@@ -29,20 +61,29 @@ class Projects(Model):
     created_at = DateTimeField(default = datetime.datetime.now)
 
     class Meta:
-        database = mydb
+        database = get_database()
+
 
 def connect():
+    # Get the correct database connection
+    db = get_database()
+    
     try:
-        mydb.connect()
+        # Initialize database
+        db_int()
+        # Connect to the database given the previous variable
+        db.connect()
         print("Connected to MySQL")
     except OperationalError as e:
         print("Error connecting to MySQL DB")
         print(e)
 
 def create_tables():
+    db = get_database()
+
     try:
-        mydb.create_tables([TimeLinePost])
-        mydb.create_tables([Projects])
+        db.create_tables([TimeLinePost])
+        db.create_tables([Projects])
         print("Created tables successfully")
     except OperationalError as e:
         print("Error creating tables")

--- a/example.env
+++ b/example.env
@@ -1,3 +1,4 @@
+TESTING=false
 URL=localhost:5000
 MYSQL_HOST=
 MYSQL_USER=

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,94 @@
+import unittest
+import os
+os.environ['TESTING'] = 'true'
+
+from app import app
+
+class AppTestCase(unittest.TestCase):
+  def setUp(self):
+    self.client = app.test_client()
+  
+  def test_home(self):
+    response = self.client.get('/')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert '<title>Loading...</title>' in html
+    assert 'LOADING' in html
+    assert "Press 'SPACE' to begin or 'ESC' to skip intr to skip intro" in html
+    assert '<script src="../static/scripts/index.js"></script>' in html
+
+  def test_timeline(self):
+    # Testing timeline GET to see if it's empty
+    response = self.client.get('/api/timeline_post')
+    assert response.status_code == 200
+    assert response.is_json
+    json = response.get_json()
+    assert "timeline_post" in json
+    assert len(json["timeline_post"]) == 0
+
+    # Testing /timline page to see if nothing is rendered
+    response = self.client.get('/timeline')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert html.count('<div class="post">') == 0
+
+    # Test timeline POST and check the returned values
+    response = self.client.post('/api/timeline_post', data = {
+      "name": "John Doe",
+      "email": "John@mail.com",
+      "content": "Hello world, I'm John!"})
+    assert response.status_code == 200
+    assert response.is_json
+    json = response.get_json()
+    assert json["name"] == "John Doe"
+    assert json["email"] == "John@mail.com"
+    assert json["content"] == "Hello world, I'm John!"
+
+    # Test timeline GET to see if it was published correctly
+    response = self.client.get('/api/timeline_post')
+    assert response.status_code == 200
+    assert response.is_json
+    json = response.get_json()
+    assert "timeline_post" in json
+    assert len(json["timeline_post"]) == 1
+    json = json["timeline_post"][0]
+    assert json["name"] == "John Doe"
+    assert json["email"] == "John@mail.com"
+    assert json["content"] == "Hello world, I'm John!"
+
+    # Test /timeline page to see if it was published/rendered
+    response = self.client.get('/timeline')
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert html.count('<div class="post">') == 1
+    assert '<p class="name">John Doe</p>' in html
+    # Using &#39; to represent ' in html
+    assert '<p class="content">Hello world, I&#39;m John!</p>' in html
+
+  def test_malformed_timeline_post(self):
+    # POST request missing name
+    response = self.client.post('/api/timeline_post', data = {
+      "name": "",
+      "email": "john@example.com",
+      "content": "Hello world, I'm John!"})
+    assert response.status_code == 400
+    html = response.get_data(as_text=True)
+    assert "Invalid name" in html
+    
+    # POST request missing content
+    response = self.client.post('/api/timeline_post', data = {
+      "name": "John Doe",
+      "email": "john@example.com", 
+      "content": ""})
+    assert response.status_code == 400
+    html = response.get_data(as_text=True)
+    assert "Invalid content" in html
+
+    # POST request missing malformed email
+    response = self.client.post('/api/timeline_post', data = {
+      "name": "John Doe",
+      "email": "not-an-email", 
+      "content": "Hello world, I'm John!"})
+    assert response.status_code == 400
+    html = response.get_data(as_text=True)
+    assert "Invalid email" in html

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,5 +1,4 @@
 import unittest
-import datetime
 from peewee import *
 
 from app.utils.mysql_init import TimeLinePost


### PR DESCRIPTION
#38 
Added the integration test for the site. The tests check multiple points within the application such as the welcome page and the timeline api interaction. All these are done in a temporal db which gets deleted once the tests are done.

<h3>Running the tests:</h3>

```python
python -m unittest discover -v tests

or

python3 -m unittest discover -v tests
``` 

<h3>Results:</h3>
<img width="755" alt="Screenshot 2023-07-19 at 3 08 21 p m" src="https://github.com/YeyoM/PE-MLH-Portfolio/assets/65473367/da7fd5a5-d1ee-4e71-89a3-f238de6291f0">


---
<h2>Some notes:</h2>

I was able to revert back the **/utils** structure that was changed in issue #37. 🥳

After some digging I found that `peewee` doesn't like that the db isn't initialized before connecting to it in some cases like unit testing. Also, it looks like when running unittesting, the `__init__.py` file gets executed, which executes the `connect()` function which doesn't seem to know what `db` it's pointing to...

To solve this I made some changes to `mysql_init.py` which seems to have solved the problem:

1. Loaded the environment variables directly on file since unittesting does not load them from `__init__.py`
```python
# Load environment variables --> Done for testing purposes
load_dotenv()
``` 

2. Initialized `mydb` variable as None and created a function `get_database()` to get the database when used. I did this since global variables also don't get recognized as loaded when running unit tests
```python
# Initialize database as None
mydb = None

# Function to get database connection depending on the environment (Testing or not)
def get_database():
    global mydb

    if mydb is None:
        if os.getenv("TESTING") == "true":
            print("Running in test mode")
            mydb = SqliteDatabase('file:memory?mode=memory&cache=shared', uri=True)
        else:
            mydb = MySQLDatabase(os.getenv("MYSQL_DATABASE"),
                user=os.getenv("MYSQL_USER"),
                password=os.getenv("MYSQL_PASSWORD"),
                host=os.getenv("MYSQL_HOST"),
                port=3306
            )
    
    return mydb
```

3. Created function `db_init()` which initializes the db right before `db.connect()` is ran which was one of the main causes of the problem
```python
# Function to initialize database to prevent when testing
def db_int():
    # Get database connection
    db = get_database()
    
    if os.getenv("TESTING") == "true":
            db.init('file:memory?mode=memory&cache=shared')
    else:
        db.init(os.getenv("MYSQL_DATABASE"),
            user=os.getenv("MYSQL_USER"),
            password=os.getenv("MYSQL_PASSWORD"),
            host=os.getenv("MYSQL_HOST"),
            port=3306
        )
```

4. Finally, in the `connect()` function, the db is obtained from the previously mentioned function and then `db_init()` is ran to initialize the db right before connecting to it.
```python
def connect():
    # Get the correct database connection
    db = get_database()
    
    try:
        # Initialize database
        db_int()
        # Connect to the database given the previous variable
        db.connect()
        print("Connected to MySQL")
    except OperationalError as e:
        print("Error connecting to MySQL DB")
        print(e)
```
